### PR TITLE
feat: Add workflow for deploying PR previews

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -61,3 +61,51 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  build-and-deploy-pr-preview:
+    needs: test
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      pull-requests: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: 2.4.2
+
+      - name: Build application for PR preview
+        run: deno task build-pr-preview --pr-number=${{ github.event.number }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./build"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Post preview link
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 PR Preview available at: ${{ steps.deployment.outputs.page_url }}`
+            })

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,7 @@
   "tasks": {
     "dev": "deno run --watch main.ts",
     "build": "deno run --allow-read --allow-write --allow-run --allow-env --allow-net scripts/build.ts",
+    "build-pr-preview": "deno run --allow-read --allow-write --allow-run --allow-env --allow-net scripts/build-pr-preview.ts",
     "bundle": "deno bundle --platform=browser --config=./deno.json --import-map=./import_map.json ./src/index.tsx ./build/index.js",
     "build:esbuild": "deno run --allow-read --allow-write --allow-run --allow-env --allow-net scripts/build_esbuild.ts",
     "serve": "deno run --allow-read --allow-net scripts/serve.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -1346,6 +1346,7 @@
     "https://deno.land/std@0.200.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
     "https://deno.land/std@0.200.0/assert/assert.ts": "9a97dad6d98c238938e7540736b826440ad8c1c1e54430ca4c4e623e585607ee",
     "https://deno.land/std@0.200.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://deno.land/std@0.200.0/flags/mod.ts": "a5ac18af6583404f21ea03771f8816669d901e0ff4374020870334d6f61d73d5",
     "https://deno.land/std@0.200.0/fs/_util.ts": "fbf57dcdc9f7bc8128d60301eece608246971a7836a3bb1e78da75314f08b978",
     "https://deno.land/std@0.200.0/fs/copy.ts": "66edc2baea085afbe98d60b16ae93f4eef84fbf774b6d671e6ff2cfd52d4c860",
     "https://deno.land/std@0.200.0/fs/empty_dir.ts": "2e52cd4674d18e2e007175c80449fc3d263786a1361e858d9dfa9360a6581b47",

--- a/scripts/build-pr-preview.ts
+++ b/scripts/build-pr-preview.ts
@@ -1,0 +1,75 @@
+// Build script for pull request previews of the Cashsplitter SPA
+import {
+  copy,
+  emptyDir,
+  ensureDir,
+} from "https://deno.land/std@0.200.0/fs/mod.ts";
+import { parse } from "https://deno.land/std@0.200.0/flags/mod.ts";
+
+const BUILD_DIR = "./build";
+const STATIC_DIR = "./static";
+const ENTRY_POINT = "./src/index.tsx";
+const OUTPUT_BUNDLE = `${BUILD_DIR}/index.js`;
+
+async function build(basePath: string) {
+  console.log("Building Cashsplitter PR Preview...");
+
+  // Clean or create build directory
+  await emptyDir(BUILD_DIR);
+  await ensureDir(BUILD_DIR);
+
+  // Copy static files, modifying index.html
+  console.log("Copying static files and modifying index.html...");
+  for await (const dirEntry of Deno.readDir(STATIC_DIR)) {
+    const srcPath = `${STATIC_DIR}/${dirEntry.name}`;
+    const destPath = `${BUILD_DIR}/${dirEntry.name}`;
+    if (dirEntry.name === "index.html") {
+      let html = await Deno.readTextFile(srcPath);
+      html = html.replace(
+        "<head>",
+        `<head>\n    <base href="${basePath}">`,
+      );
+      await Deno.writeTextFile(destPath, html);
+    } else {
+      await copy(srcPath, destPath, { overwrite: true });
+    }
+  }
+
+  // Bundle the application
+  console.log("Bundling TypeScript/JSX files...");
+  const { code, stderr } = await new Deno.Command("deno", {
+    args: [
+      "bundle",
+      "--platform=browser",
+      ENTRY_POINT,
+      "--output",
+      OUTPUT_BUNDLE,
+    ],
+  }).output();
+
+  if (code === 0) {
+    console.log("Bundle created successfully at", OUTPUT_BUNDLE);
+  } else {
+    const errorString = new TextDecoder().decode(stderr);
+    console.error("Bundle creation failed:");
+    console.error(errorString);
+    Deno.exit(1);
+  }
+
+  console.log("Build completed");
+}
+
+if (import.meta.main) {
+  const flags = parse(Deno.args, {
+    string: ["pr-number"],
+  });
+
+  const prNumber = flags["pr-number"];
+  if (!prNumber) {
+    console.error("Error: --pr-number flag is required.");
+    Deno.exit(1);
+  }
+
+  const basePath = `/cashsplitter/pr-preview/pr-${prNumber}/`;
+  await build(basePath);
+}


### PR DESCRIPTION
This change introduces a new GitHub Actions workflow to build and deploy a preview version of the application for each pull request.

A new build script `scripts/build-pr-preview.ts` is added to handle the creation of a `<base>` tag in the `index.html`, which is necessary for the preview to work in a subdirectory.

The main workflow `test-and-deploy.yml` is updated with a new job `build-and-deploy-pr-preview` that:
- Triggers on pull requests.
- Builds the application using the new script.
- Deploys the preview to GitHub Pages.
- Posts a comment on the PR with a link to the preview.